### PR TITLE
feat: added configurable password validation 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ TW_DB_USERNAME=postgres
 TW_DB_PASSWORD=12345678
 TW_DB_ENABLE_SSL=false
 TW_VITE_API_URL=http://localhost:3000/v1
+TW_VITE_PASSWORD_VALIDATION_POLICY="normal" # avaiable options: very_strict, strict, normal, and none

--- a/packages/docs/docs/getting-started/environment-variables.md
+++ b/packages/docs/docs/getting-started/environment-variables.md
@@ -103,11 +103,12 @@ For logging and observability environment variables, we have [a dedicated docume
 
 Any frontend environment variable is prefixed with `TW_VITE_`, e.g `TW_VITE_API_URL`.
 
-| Variable              | Description                           | Default                  | Required |
-| --------------------- | ------------------------------------- | ------------------------ | -------- |
-| `TW_VITE_API_URL`     | The URL to the tillywork API          | http://localhost:3000/v1 | No       |
-| `TW_VITE_DOCS_URL`    | URL to tillywork documentation        | https://docs.tilly.work  | No       |
-| `TW_VITE_POSTHOG_KEY` | The Posthog project key for analytics |                          | No       |
+| Variable                             | Description                           | Default                  | Required |
+| ------------------------------------ | ------------------------------------- | ------------------------ | -------- |
+| `TW_VITE_API_URL`                    | The URL to the tillywork API          | http://localhost:3000/v1 | No       |
+| `TW_VITE_DOCS_URL`                   | URL to tillywork documentation        | https://docs.tilly.work  | No       |
+| `TW_VITE_POSTHOG_KEY`                | The Posthog project key for analytics |                          | No       |
+| `TW_VITE_PASSWORD_VALIDATION_POLICY` | Password Validation policy            | none                     | No       |
 
 ---
 

--- a/packages/frontend/src/components/common/auth/RegisterForm.vue
+++ b/packages/frontend/src/components/common/auth/RegisterForm.vue
@@ -125,7 +125,7 @@ async function handleRegister() {
                 label="Password*"
                 type="password"
                 required
-                :rules="[rules.required]"
+                :rules="[rules.required, rules.password]"
               />
               <!-- <v-phone-input
                 v-model="createUserDto.phoneNumber"

--- a/packages/frontend/src/utils/validation.ts
+++ b/packages/frontend/src/utils/validation.ts
@@ -1,3 +1,29 @@
+const passwordPolicy =
+  import.meta.env.TW_VITE_PASSWORD_VALIDATION_POLICY || 'none';
+
+const getPasswordRule = () => {
+  switch (passwordPolicy) {
+    case 'very_strict':
+      return (v: string) =>
+        !v ||
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{12,}$/.test(v) ||
+        'Password must be at least 12 characters, include uppercase, lowercase, number, and special character';
+    case 'strict':
+      return (v: string) =>
+        !v ||
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/.test(v) ||
+        'Password must be at least 8 characters, include uppercase, lowercase, and number';
+    case 'normal':
+      return (v: string) =>
+        !v ||
+        /^.{6,}$/.test(v) ||
+        'Password must be at least 6 characters long';
+    case 'none':
+    default:
+      return () => true;
+  }
+};
+
 const validationUtils = {
   rules: {
     required: (v: any) =>
@@ -14,6 +40,7 @@ const validationUtils = {
       !v ||
       /^(https?:\/\/)?([\w\-]+\.)+[\w\-]+(\/[\w\-./?%&=]*)?$/i.test(v) ||
       'Invalid URL format',
+    password: getPasswordRule(),
   },
 };
 


### PR DESCRIPTION
# Description 

This PR introduces configurable password validation to enhance security while allowing self-hosters to customize the validation policy via environment variables. Addresses issue #180. 

## Demo (password input changed to text for demonstration purposes):

Before:

[before.webm](https://github.com/user-attachments/assets/c8894956-2ac3-4ae4-a413-d1232de201d9)


After:

[after.webm](https://github.com/user-attachments/assets/e7e4a65a-6318-4f91-85bb-19024b770826)

